### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,6 @@ Author: Kristen Syme, Zachary Garfield, Ed Hagen
 Maintainer: Ed Hagen <ehagen@gmail.com>
 Description: For details, see Syme, Garfield and Hagen. Testing the bargaining vs. inclusive fitness models
              of suicidal behavior against the ethnographic record.
-             http://dx.doi.org/10.1016/j.evolhumbehav.2015.10.005
+             https://doi.org/10.1016/j.evolhumbehav.2015.10.005
 License: CC BY
 LazyData: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # hrafsuicidedata
 R data package for:
 
-Syme KL, Garfield ZH and Hagen EH. Testing the bargaining vs. inclusive fitness models of suicidal behavior against the ethnographic record. http://dx.doi.org/10.1016/j.evolhumbehav.2015.10.005
+Syme KL, Garfield ZH and Hagen EH. Testing the bargaining vs. inclusive fitness models of suicidal behavior against the ethnographic record. https://doi.org/10.1016/j.evolhumbehav.2015.10.005
 
 To install:
 
     library(devtools)
     install_github("grasshoppermouse/hrafsuicidedata")
 
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.30983.svg)](http://dx.doi.org/10.5281/zenodo.30983)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.30983.svg)](https://doi.org/10.5281/zenodo.30983)

--- a/man/hrafsuicidedata-package.Rd
+++ b/man/hrafsuicidedata-package.Rd
@@ -32,7 +32,7 @@ Maintainer: Ed Hagen <ehagen@gmail.com>
 
 }
 \references{
-Syme K, Hagen EH and Garfield Z. Testing the bargaining vs. inclusive fitness models of suicidal behavior against the ethnographic record. \link{http://dx.doi.org/10.1016/j.evolhumbehav.2015.10.005}
+Syme K, Hagen EH and Garfield Z. Testing the bargaining vs. inclusive fitness models of suicidal behavior against the ethnographic record. \link{https://doi.org/10.1016/j.evolhumbehav.2015.10.005}
 }
 \keyword{ package }
 \seealso{


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all static DOI links.

Cheers!